### PR TITLE
Add version parameter in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ the task in the component. For example, queue using AWS SQS
         'class' => 'UrbanIndo\Yii2\Queue\SqsQueue',
         'module' => 'task',
         'url' => 'https://sqs.ap-southeast-1.amazonaws.com/123456789012/queue',
-            'config' => [
-                'key' => 'AKIA1234567890123456',
-                'secret' => '1234567890123456789012345678901234567890',
-            'region' => 'ap-southeast-1',
-            'version' => 'latest'
+		'config' => [
+			'key' => 'AKIA1234567890123456',
+			'secret' => '1234567890123456789012345678901234567890',
+			'region' => 'ap-southeast-1',
+			'version' => 'latest'
         ],
     ]
 ]

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ the task in the component. For example, queue using AWS SQS
                 'key' => 'AKIA1234567890123456',
                 'secret' => '1234567890123456789012345678901234567890',
             'region' => 'ap-southeast-1',
+            'version' => 'latest'
         ],
     ]
 ]
@@ -77,7 +78,7 @@ e.g.
 
 ```php
 class FooController extends UrbanIndo\Yii2\Queue\Worker\Controller {
-    
+
     public function actionBar($param1, $param2){
         echo $param1;
     }
@@ -92,7 +93,7 @@ e.g.
 
 ```php
 class FooController extends UrbanIndo\Yii2\Queue\Worker\Controller {
-    
+
     public function actionBar($param1, $param2){
         try {
         } catch (\Exception $ex){
@@ -152,7 +153,7 @@ To use this, add behavior in a component and implement the defined event handler
             [
                 'class' => \UrbanIndo\Yii2\Queue\Behaviors\DeferredEventBehavior::class,
                 'events' => [
-                    self::EVENT_AFTER_VALIDATE => 'deferAfterValidate', 
+                    self::EVENT_AFTER_VALIDATE => 'deferAfterValidate',
                 ]
             ]
         ]);
@@ -182,7 +183,7 @@ object whose attributes are assigned from the attributes of the original object.
 
 ### Web End Point
 
-We can use web endpoint to use the queue by adding `\UrbanIndo\Yii2\Queue\Web\Controller` 
+We can use web endpoint to use the queue by adding `\UrbanIndo\Yii2\Queue\Web\Controller`
 to the controller map.
 
 For example


### PR DESCRIPTION
I followed the documentation but I got an error when version was not supplied. 

```
Running new process...

Exception 'InvalidArgumentException' with message 'Missing required client configuration options:

version: (string)

  A "version" configuration value is required. Specifying a version constraint
  ensures that your code will not be affected by a breaking change made to the
  service. For example, when using Amazon S3, you can lock your API version to
  "2006-03-01".

  Your build of the SDK has the following version(s) of "sqs": * "2012-11-05"

  You may provide "latest" to the "version" configuration value to utilize the
  most recent available API version that your client's API provider can find.
  Note: Using 'latest' in a production application is not recommended.

  A list of available API versions can be found on each client's API documentation
  page: http://docs.aws.amazon.com/aws-sdk-php/v3/api/index.html. If you are
  unable to load a specific API version, then you may need to update your copy of
  the SDK.'
```
