### PR TITLE
Fix doc on create new post on source code

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ e.g.
 
 ```php
 class FooController extends UrbanIndo\Yii2\Queue\Worker\Controller {
-    
+
     public function actionBar($param1, $param2){
         echo $param1;
     }
@@ -92,7 +92,7 @@ e.g.
 
 ```php
 class FooController extends UrbanIndo\Yii2\Queue\Worker\Controller {
-    
+
     public function actionBar($param1, $param2){
         try {
         } catch (\Exception $ex){
@@ -121,7 +121,7 @@ use UrbanIndo\Yii2\Queue\Job;
 
 $route = 'foo/bar';
 $data = ['param1' => 'foo', 'param2' => 'bar'];
-Yii::$app->queue->post(new Job($route, $data));
+Yii::$app->queue->post(new Job(['route' => $route, 'data' => $data]));
 ```
 
 Job can also be posted from the console. The data in the second parameter is in
@@ -152,7 +152,7 @@ To use this, add behavior in a component and implement the defined event handler
             [
                 'class' => \UrbanIndo\Yii2\Queue\Behaviors\DeferredEventBehavior::class,
                 'events' => [
-                    self::EVENT_AFTER_VALIDATE => 'deferAfterValidate', 
+                    self::EVENT_AFTER_VALIDATE => 'deferAfterValidate',
                 ]
             ]
         ]);
@@ -182,7 +182,7 @@ object whose attributes are assigned from the attributes of the original object.
 
 ### Web End Point
 
-We can use web endpoint to use the queue by adding `\UrbanIndo\Yii2\Queue\Web\Controller` 
+We can use web endpoint to use the queue by adding `\UrbanIndo\Yii2\Queue\Web\Controller`
 to the controller map.
 
 For example


### PR DESCRIPTION
I got an error when following the documentation for this part below: 

```
$route = 'foo/bar';
$data = ['param1' => 'foo', 'param2' => 'bar'];
Yii::$app->queue->post(new Job($route, $data));
```

The error said

```
PHP Warning – yii\base\ErrorException

Invalid argument supplied for foreach()

1. in /Users/masbugan/Sites/gado/yiisoft/yii2/BaseYii.php at line517
508509510511512513514515516517518519520521522523524525526

 
    /**
     * Configures an object with the initial property values.
     * @param object $object the object to be configured
     * @param array $properties the property initial values given in terms of name-value pairs.
     * @return object the object itself
     */
    public static function configure($object, $properties)
    {
        foreach ($properties as $name => $value) {
            $object->$name = $value;
        }
 
        return $object;
    }
 
    /**
     * Returns the public member variables of an object.
     * This method is provided such that we can get the public member variables of an object.

2. in /Users/masbugan/Sites/gado/vendor/yiisoft/yii2/BaseYii.php – yii\base\ErrorHandler::handleError(2, 'Invalid argument supplied for fo...', '/Users/masbugan/Sites/gado-...', 517, ...)at line517
3. in /Users/masbugan/Sites/gado/vendor/yiisoft/yii2/base/Object.php – yii\BaseYii::configure(UrbanIndo\Yii2\Queue\Job, 'foo/bar')at line105
```

The last line is supposed to be
```
Yii::$app->queue->post(new Job(['route' => $route, 'data' => $data]));
```