### PR TITLE
fix action argument

### DIFF
--- a/src/Worker/Controller.php
+++ b/src/Worker/Controller.php
@@ -56,22 +56,25 @@ abstract class Controller extends \yii\base\Controller {
             $method = new \ReflectionMethod($action, 'run');
         }
 
-        $args = array_values($params);
-
+        $args = $params;
+        
         $missing = [];
+        
         foreach ($method->getParameters() as $i => $param) {
-            if ($param->isArray() && isset($args[$i])) {
-                $args[$i] = preg_split('/\s*,\s*/', $args[$i]);
+            /* @var $param \ReflectionParameter */
+            $name = $param->getName();
+            if ($param->isArray() && isset($params[$name])) {
+                $args[$name] = preg_split('/\s*,\s*/', $params[$name]);
             }
-            if (!isset($args[$i])) {
+            if (!isset($args[$name])) {
                 if ($param->isDefaultValueAvailable()) {
-                    $args[$i] = $param->getDefaultValue();
+                    $args[$name] = $param->getDefaultValue();
                 } else {
-                    $missing[] = $param->getName();
+                    $missing[] = $name;
                 }
             }
         }
-
+        
         if (!empty($missing)) {
             throw new \Exception(\Yii::t('yii',
                     'Missing required arguments: {params}',


### PR DESCRIPTION
Previously, when I put just required parameter on the action, I got an error. 
So I must put all the parameter including the optional parameter with default values and must be in the right order. 

And when I put array to the parameter, I got an error, The error said. *Array given, but string expected as argument*

So I change this method in order to receive array as a parameter and can execute just using the necessary parameter to process, I also change the process based on parameter name, not based on the order of parameter.