### PR TITLE
Fix error starting new processes

### DIFF
--- a/src/Console/Controller.php
+++ b/src/Console/Controller.php
@@ -97,7 +97,7 @@ class Controller extends \yii\console\Controller
      */
     protected function getScriptPath()
     {
-        return getcwd() . DIRECTORY_SEPARATOR . $_SERVER['argv'][0];
+        return realpath($_SERVER['argv'][0]);
     }
 
     /**


### PR DESCRIPTION
When queue listener starting with full path it can't start workers. Example:

``` bash
$ cd /tmp
$ /usr/bin/php /var/www/yii queue/listen
Listening to queue...
Running new process...
Could not open input file: /tmp//var/www/yii
```

The same happens, when I'm trying to start listener via webmin cron module.
