### PR TITLE
Add logging in Console Controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor/
+.idea/*

--- a/src/Console/Controller.php
+++ b/src/Console/Controller.php
@@ -8,6 +8,7 @@
 
 namespace UrbanIndo\Yii2\Queue\Console;
 
+use Yii;
 use UrbanIndo\Yii2\Queue\Job;
 use UrbanIndo\Yii2\Queue\Queue;
 use yii\base\InvalidParamException;
@@ -25,7 +26,7 @@ use yii\base\InvalidParamException;
  * ];
  * 
  * OR
- * 
+ *
  * return [
  *    // ...
  *     'controllerMap' => [
@@ -149,15 +150,20 @@ class Controller extends \yii\console\Controller
         $process->setTimeout($timeout);
         $process->setIdleTimeout(null);
         $process->run();
+
+        $out = $process->getOutput();
+        $err = $process->getErrorOutput();
+
         if ($process->isSuccessful()) {
-            //TODO logging.
-            $this->stdout($process->getOutput() . PHP_EOL);
-            $this->stdout($process->getErrorOutput() . PHP_EOL);
+            $this->stdout($out . PHP_EOL);
+            $this->stdout($err . PHP_EOL);
         } else {
-            //TODO logging.
-            $this->stdout($process->getOutput() . PHP_EOL);
-            $this->stdout($process->getErrorOutput() . PHP_EOL);
+            $this->stderr($out . PHP_EOL);
+            $this->stderr($err . PHP_EOL);
+            Yii::warning($out, 'yii2queue');
+            Yii::warning($err, 'yii2queue');
         }
+
     }
 
     /**
@@ -170,12 +176,15 @@ class Controller extends \yii\console\Controller
             switch ($signal) {
                 case SIGTERM:
                     $this->stderr('Caught SIGTERM');
+                    Yii::error('Caught SIGTERM', 'yii2queue');
                     exit;
                 case SIGKILL:
                     $this->stderr('Caught SIGKILL');
+                    Yii::error('Caught SIGKILL', 'yii2queue');
                     exit;
                 case SIGINT:
                     $this->stderr('Caught SIGINT');
+                    Yii::error('Caught SIGINT', 'yii2queue');
                     exit;
             }
         };

--- a/src/Queue.php
+++ b/src/Queue.php
@@ -194,7 +194,7 @@ abstract class Queue extends \yii\base\Component
         if (!$beforeEvent->isValid) {
             return;
         }
-        \Yii::info('Running job', 'yii2queue');
+        \Yii::info("Running job #: {$job->id}", 'yii2queue');
         try {
             if ($job->isCallable()) {
                 $retval = $job->runCallable();
@@ -230,7 +230,7 @@ abstract class Queue extends \yii\base\Component
         $this->trigger(self::EVENT_AFTER_RUN, new Event(['job' => $job, 'returnValue' => $retval]));
         
         if ($retval !== false) {
-            \Yii::info('Deleting job', 'yii2queue');
+            \Yii::info("Deleting job #: {$job->id}", 'yii2queue');
             $this->delete($job);
         } else if ($this->releaseOnFailure) {
             $this->release($job);


### PR DESCRIPTION
Added the the ability to excluded certain items from being included in the log.  For instance, the std output for "Running new process... No job" was causing massive log files.  The user can exclude what actions they would like to omit from the log.  Additionally, the user may now choose to log the output to the console, or they can choose to log it using Yii to the app.log runtime file.