### PR TITLE
修复未设置 module 时，报 runAction on NULL 的 bug 问题

### DIFF
--- a/src/Queue.php
+++ b/src/Queue.php
@@ -122,7 +122,11 @@ abstract class Queue extends \yii\base\Component
     public function init()
     {
         parent::init();
-        $this->module = \Yii::$app->getModule($this->module);
+        if($this->module) {
+            $this->module = \Yii::$app->getModule($this->module);
+        } else {
+            $this->module = \Yii::$app;
+        }
     }
 
     /**


### PR DESCRIPTION
执行  ./yii queue/run 时，提示如下：
```
Exception 'Error' with message 'Call to a member function runAction() on null'
in /data/vendor/urbanindo/yii2-queue/src/Queue.php:202
```

使用的是 yii2 advance 版本，main-local.php 如下：
```
'redis' => [
            'class' => '\yii\redis\Connection',
            'hostname' => 'redis-host',
            'port' => 6379,
        ],
'queue' => [
            'class' => '\UrbanIndo\Yii2\Queue\Queues\RedisQueue',
            'key' => 'Yunlong'
        ]
```
在 queue 中未设置 module 属性，导致以上错误