### PR TITLE
add array type hint to env argument and set default to null

### DIFF
--- a/src/Console/Controller.php
+++ b/src/Console/Controller.php
@@ -110,7 +110,7 @@ class Controller extends \yii\console\Controller
      * The format for each element is 'KEY=VAL'.
      * @return void
      */
-    public function actionListen($cwd = null, $timeout = null, $env = [])
+    public function actionListen($cwd = null, $timeout = null, array $env = null)
     {
         $this->stdout("Listening to queue...\n");
         $this->initSignalHandler();
@@ -157,7 +157,7 @@ class Controller extends \yii\console\Controller
         $command,
         $cwd = null,
         $timeout = null,
-        array $env = []
+        array $env = null
     ) {
         $process = new \Symfony\Component\Process\Process(
             $command,


### PR DESCRIPTION
Add `array` type hint to `$env` parameter. Yii2 will generate the array by splitting the input string on commas: http://www.yiiframework.com/doc-2.0/guide-tutorial-console.html#arguments
So we can set the env with `KEY_1=VAL_1,KEY_2=VAL_2`.

Set default value of `$env` to null. `\Symfony\Component\Process\Process` will use the same environment as the current PHP process if `$env` is `null`: http://api.symfony.com/2.8/Symfony/Component/Process/Process.html#method___construct