### PR TITLE
implementing multi threading, pushing processes into background

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,23 @@
 language: php
+dist: trusty
 php:
   - 5.5
   - 5.6
   - hhvm
-  #- nightly
-  
+  - 7
+  - 7.1
+
 services:
   - mysql
   - redis-server
-  
-script: ./vendor/bin/phpunit
-  
+
+cache:
+  directories:
+    - $HOME/.composer/cache/files
+
+script:
+  - ./vendor/bin/phpunit --coverage-clover 'reports/clover.xml'
+
 before_script:
   #MySQL database init
   - mysql -uroot -e "CREATE DATABASE IF NOT EXISTS test;"
@@ -19,5 +26,7 @@ before_script:
 
 install:
   - travis_retry composer self-update && composer --version
-  - travis_retry composer install --prefer-source --no-interaction
+  - travis_retry composer install --prefer-dist --no-interaction
 
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This provides queue component for Yii2.
 [![Total Downloads](https://poser.pugx.org/urbanindo/yii2-queue/downloads.svg)](https://packagist.org/packages/urbanindo/yii2-queue)
 [![Latest Unstable Version](https://poser.pugx.org/urbanindo/yii2-queue/v/unstable.svg)](https://packagist.org/packages/urbanindo/yii2-queue)
 [![Build Status](https://travis-ci.org/urbanindo/yii2-queue.svg)](https://travis-ci.org/urbanindo/yii2-queue)
+[![codecov](https://codecov.io/gh/urbanindo/yii2-queue/branch/master/graph/badge.svg)](https://codecov.io/gh/urbanindo/yii2-queue)
 
 ## Requirements
 You need [PCNT extension](http://php.net/manual/en/book.pcntl.php) enabled to run listener

--- a/src/ProcessRunner.php
+++ b/src/ProcessRunner.php
@@ -171,6 +171,7 @@ class ProcessRunner extends \yii\base\Component implements IteratorAggregate
      * if we are in single threaded mode, wait for it to finish before moving on
      * @param string $command the command to exec
      * @param string $cwd
+     * @return void
      */
     public function runProcess( $command )
     {
@@ -216,7 +217,7 @@ class ProcessRunner extends \yii\base\Component implements IteratorAggregate
      * clean up defunct processes running in background
      * @return void
      */
-    protected function cleanUpProcs()
+    public function cleanUpProcs()
     {
         if ( is_array($this->procs) && ($cntProcs = count($this->procs)) > 0 ) {
 
@@ -244,7 +245,7 @@ class ProcessRunner extends \yii\base\Component implements IteratorAggregate
      * @param int $pid process pid
      * @return void
      */
-    protected function cleanUpProc(Process $process, $pid)
+    public function cleanUpProc(Process $process, $pid)
     {
         $process->checkTimeout();
 
@@ -282,7 +283,7 @@ class ProcessRunner extends \yii\base\Component implements IteratorAggregate
      * wait for all to finish
      * @return void
      */
-    protected function cleanUpAll( $signal = null, $propagate = false )
+    public function cleanUpAll( $signal = null, $propagate = false )
     {
         $this->stdout('Cleaning processes: ' . $this->getOpenedProcsCount() . PHP_EOL);
 

--- a/src/ProcessRunner.php
+++ b/src/ProcessRunner.php
@@ -294,10 +294,19 @@ class ProcessRunner extends \yii\base\Component implements IteratorAggregate
         while ( $this->getOpenedProcsCount() ) {
 
             foreach ( $this->procs as $pid => $process ) {
-
-                if ( $process->isRunning() && $propagate && $signal ) {
+                
+                if ( $process->isRunning()
+                    && $process->getPid()
+                    && $propagate
+                    && $signal )
+                {
                     $this->stdout(sprintf('Sending signal %d to pid %d', $signal, $pid) . PHP_EOL);
-                    $process->signal($signal);
+                    
+                    try {
+                        $process->signal($signal);
+                    } catch ( \Symfony\Component\Process\Exception\LogicException $e ) {
+                        $this->stdout('Process was already stopped.');
+                    }
                 }
 
                 $this->cleanUpProc($process, $pid);

--- a/src/ProcessRunner.php
+++ b/src/ProcessRunner.php
@@ -1,0 +1,436 @@
+<?php
+/**
+ * ProcessRunner class file.
+ *
+ * @author Marek Petras <mark@markpetras.eu>
+ * @since 2017.08.01
+ */
+
+namespace UrbanIndo\Yii2\Queue;
+
+use IteratorAggregate;
+use ArrayIterator;
+use Symfony\Component\Process\Process;
+use Yii;
+use yii\helpers\Console;
+use yii\base\InvalidConfigException;
+
+/**
+ * The process runner is responsible for all the threads management
+ * Listens to the queue, based on the config launches x number of processes
+ * Cleans zombies after they are done, in single threaded mode, runs processes in foreground
+ *
+ * @author Marek Petras <mark@markpetras.eu>
+ * @since 2017.08.01
+ */
+class ProcessRunner extends \yii\base\Component implements IteratorAggregate
+{
+    /**
+     * @var string $cwd working directory to launch the sub processes in; default to current
+     */
+    protected $cwd = null;
+
+    /**
+     * @var array $env enviromental vars to be passed to the sub process
+     */
+    protected $env = [];
+
+    /**
+     * @var string $scriptPath the yii executable
+     */
+    private $_scriptPath = null;
+
+    /**
+     * @var Queue $queue queue
+     */
+    private $_queue;
+
+    /**
+     * @var array $procs current processes
+     */
+    private $procs = [];
+
+    /**
+     * queue setter
+     * @param Queue $queue the job queue
+     * @return self
+     */
+    public function setQueue( Queue $queue )
+    {
+        $this->_queue = $queue;
+        return $this;
+    }
+
+    /**
+     * queue getter
+     * @return Queue
+     */
+    public function getQueue()
+    {
+        return $this->_queue;
+    }
+
+    /**
+     * set yii executable
+     * @param string $scriptPath real path to the file
+     * @return self
+     * @throws InvalidConfigException on non existent file
+     */
+    public function setScriptPath( $scriptPath )
+    {
+        if ( !is_executable($scriptPath) ) {
+            throw new InvalidConfigException('Invalid script path:' . $scriptPath);
+        }
+
+        $this->_scriptPath = $scriptPath;
+        return $this;
+    }
+
+    /**
+     * retreive current script path
+     * @return string script path
+     * @throws InvalidConfigException on non existent file
+     */
+    public function getScriptPath()
+    {
+        if ( !is_executable($this->_scriptPath) ) {
+            throw new InvalidConfigException('Invalid script path:' . $this->_scriptPath);
+        }
+
+        return $this->_scriptPath;
+    }
+
+    /**
+     * IteratorAggregate implementation
+     * @return ArrayIterator running processes
+     */
+    public function getIterator()
+    {
+        return new ArrayIterator($this->procs);
+    }
+
+    /**
+     * listen to the queue, launch processes based on queue settings
+     * clean up, catch signals, propagate to sub processes if required or wait for completion
+     * launches new jobs from the queue when current < maxprocs
+     * @param string $cwd current working dir
+     * @param int $timeout timeout to be passed on to the sub processes
+     * @param array $env enviromental variables for the sub proc
+     * @return void
+     */
+    public function listen( $cwd = null, $timeout = 0, array $env = null )
+    {
+        $this->cwd = $cwd;
+        $this->env = $env;
+
+        $this->initSignalHandler();
+
+        declare(ticks = 1);
+
+        while (true) {
+
+            // determine the size of the queue
+            $queueSize = $this->getQueueSize();
+
+            $this->stdout(sprintf('queueSize: %d , opened: %d , limit: %d ',
+                    $queueSize,$this->getOpenedProcsCount(),$this->getMaxProcesses()).PHP_EOL);
+
+            // check for defunct processes
+            $this->cleanUpProcs();
+
+            // if we have queue and open spots, launch new ones
+            if ( $queueSize ) {
+                if ( $this->getCanOpenNew() ) {
+                    $this->stdout("Running new  process...\n");
+                    $this->runProcess(
+                            $this->buildCommand()
+                        );
+                }
+                else {
+                    $this->stdout(sprintf('Nothing to do, Waiting for processes to finish; queueSize: %d , opened: %d , limit: %d ',
+                        $queueSize,$this->getOpenedProcsCount(),$this->getMaxProcesses()).PHP_EOL);
+                    sleep($this->queue->waitSecondsIfNoProcesses); // wait x seconds then try cleaning up
+                }
+            }
+            else {
+                if ( $this->queue->waitSecondsIfNoQueue > 0 ) {
+                    $this->stdout('NO Queue, Waiting '.$this->queue->waitSecondsIfNoQueue.' to save cpu...' . PHP_EOL);
+                    sleep($this->queue->waitSecondsIfNoQueue);
+                }
+            }
+
+            // sleep if we want to between lanuching new processes
+            if ($this->getSleepTimeout() > 0) {
+                sleep($this->getSleepTimeout());
+            }
+        }
+    }
+
+    /**
+     * run the sub process, register it with others,
+     * if we are in single threaded mode, wait for it to finish before moving on
+     * @param string $command the command to exec
+     * @param string $cwd
+     */
+    public function runProcess( $command )
+    {
+        $process = new Process(
+            $command,
+            $this->cwd ? $this->cwd : getcwd(),
+            $this->env
+        );
+
+        $this->stdout('Running ' . $command . PHP_EOL);
+
+        $process->setTimeout($this->getTimeout());
+        $process->setIdleTimeout($this->getIdleTimeout());
+        $process->start();
+
+        $this->addProcess($process);
+
+        if ( $this->getIsSingleThreaded() ) {
+
+            $this->stdout('Running in sync mode' . PHP_EOL);
+
+            $process->wait(function($type,$data){
+                $method = 'std'.$type;
+                $this->{$method}($data);
+            });
+
+            $this->cleanUpProc($process, $process->getPid());
+        }
+    }
+
+    /**
+     * add the process to the currently running to be cleaned up after finish
+     * @param Process $process the process object
+     * @return self
+     */
+    public function addProcess( Process $process )
+    {
+        $this->procs[$process->getPid()] = $process;
+        return $this;
+    }
+
+    /**
+     * clean up defunct processes running in background
+     * @return void
+     */
+    protected function cleanUpProcs()
+    {
+        if ( is_array($this->procs) && ($cntProcs = count($this->procs)) > 0 ) {
+
+            $this->stdout('Currently see ' . $cntProcs . ' processes' . PHP_EOL);
+
+            foreach ( $this->procs as $pid => $proc) {
+                $this->cleanUpProc($proc,$pid);
+            }
+        }
+    }
+
+    /**
+     * build the command to launch sub process
+     * @return string command
+     */
+    protected function buildCommand()
+    {
+        // using setsid to stop signal propagation to allow background processes to finish even if we receive a signal
+        return "setsid " . PHP_BINARY . " {$this->scriptPath} {$this->getCommand()}";
+    }
+
+    /**
+     * check if process is still running, if not get stdout/error and clean up process
+     * @param Process $process the background process
+     * @param int $pid process pid
+     * @return void
+     */
+    protected function cleanUpProc(Process $process, $pid)
+    {
+        $process->checkTimeout();
+
+        if ( !$process->isRunning() ) {
+
+            $this->stdout('Cleanning up ' . $pid . PHP_EOL);
+
+            $process->stop();
+
+            $out = $process->getOutput();
+            $err = $process->getErrorOutput();
+
+            if ($process->isSuccessful()) {
+                $this->stdout('Success' . PHP_EOL);
+
+                // we already display output as it is piped in in single threaded mode
+                if ( !$this->getIsSingleThreaded() ) {
+                    $this->stdout($out . PHP_EOL);
+                    $this->stdout($err . PHP_EOL);
+                }
+
+            } else {
+                $this->stdout('Error' . PHP_EOL);
+                $this->stderr($out . PHP_EOL);
+                $this->stderr($err . PHP_EOL);
+                Yii::warning($out, 'yii2queue');
+                Yii::warning($err, 'yii2queue');
+            }
+
+            unset($this->procs[$pid]);
+        }
+    }
+
+    /**
+     * wait for all to finish
+     * @return void
+     */
+    protected function cleanUpAll( $signal = null, $propagate = false )
+    {
+        $this->stdout('Cleaning processes: ' . $this->getOpenedProcsCount() . PHP_EOL);
+
+        while ( $this->getOpenedProcsCount() ) {
+
+            foreach ( $this->procs as $pid => $process ) {
+
+                if ( $process->isRunning() && $propagate && $signal ) {
+                    $this->stdout(sprintf('Sending signal %d to pid %d', $signal, $pid) . PHP_EOL);
+                    $process->signal($signal);
+                }
+
+                $this->cleanUpProc($process, $pid);
+            }
+
+            sleep(1);
+        }
+    }
+
+    /**
+     * Initialize signal handler for the process.
+     * @return void
+     */
+    protected function initSignalHandler()
+    {
+        $signalHandler = function ($signal) {
+            switch ($signal) {
+                case SIGTERM:
+                    // wait for procs to finish then quit
+                    $this->stderr('Caught SIGTERM, cleaning up'.PHP_EOL);
+                    $this->cleanUpAll($signal, $this->getPropagateSignals());
+                    Yii::error('Caught SIGTERM', 'yii2queue');
+                    exit;
+                case SIGINT:
+                    // wait for procs to finish then quit
+                    $this->stderr('Caught SIGINT, cleaning up'.PHP_EOL);
+                    $this->cleanUpAll($signal, $this->getPropagateSignals());
+                    Yii::error('Caught SIGINT', 'yii2queue');
+                    exit;
+            }
+        };
+        pcntl_signal(SIGTERM, $signalHandler);
+        pcntl_signal(SIGINT, $signalHandler);
+    }
+
+    /**
+     * get the idle timeout to be passed on to Process
+     * @return ?int idle timeout
+     */
+    protected function getIdleTimeout()
+    {
+        return $this->getQueue()->idleTimeout;
+    }
+
+    /**
+     * get the timeout from the queue, seconds after which the process will timeout
+     * @return ?int timeout in seconds
+     */
+    protected function getTimeout()
+    {
+        return $this->getQueue()->timeout;
+    }
+
+    /**
+     * get sleep timeout to be slept after eaech process is launched
+     * @return ?int sleep timeout in seconds
+     */
+    protected function getSleepTimeout()
+    {
+        return $this->getQueue()->sleepTimeout;
+    }
+
+    /**
+     * check if we are running in single thread mode
+     * @return bool
+     */
+    protected function getIsSingleThreaded()
+    {
+        return $this->getMaxProcesses() === 1;
+    }
+
+    /**
+     * retrieve the size of the queue
+     * @return int size
+     */
+    protected function getQueueSize()
+    {
+        return intval($this->getQueue()->getSize());
+    }
+
+    /**
+     * retrieve number of opened processes
+     * @return int
+     */
+    protected function getOpenedProcsCount()
+    {
+        return is_array($this->procs) ? count($this->procs) : 0;
+    }
+
+    /**
+     * retrieve max processes from the queue
+     * @return int maximum number of concurent processes
+     */
+    protected function getMaxProcesses()
+    {
+        return $this->getQueue()->maxProcesses;
+    }
+
+    /**
+     * check if we can open new ones
+     * @return bool
+     */
+    protected function getCanOpenNew()
+    {
+        return $this->getOpenedProcsCount() < $this->getMaxProcesses();
+    }
+
+    /**
+     * if we should propagate signals to children
+     * @return bool
+     */
+    protected function getPropagateSignals()
+    {
+        return $this->getQueue()->propagateSignals;
+    }
+
+    /**
+     * get the command to launch the process
+     * @return string command
+     */
+    protected function getCommand()
+    {
+        return $this->getQueue()->command;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function stdout($string)
+    {
+        return Console::stdout($string);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function stderr($string)
+    {
+        return Console::stderr($string);
+    }
+}

--- a/src/ProcessRunner.php
+++ b/src/ProcessRunner.php
@@ -181,7 +181,7 @@ class ProcessRunner extends \yii\base\Component implements IteratorAggregate
             $this->env
         );
 
-        $this->stdout('Running ' . $command . PHP_EOL);
+        $this->stdout('Running ' . $command . ' (mode: ' . ($this->getIsSingleThreaded() ? 'single' : 'multi') . ')' . PHP_EOL);
 
         $process->setTimeout($this->getTimeout());
         $process->setIdleTimeout($this->getIdleTimeout());
@@ -193,12 +193,16 @@ class ProcessRunner extends \yii\base\Component implements IteratorAggregate
 
             $this->stdout('Running in sync mode' . PHP_EOL);
 
+            $pid = $process->getPid();
+
             $process->wait(function($type,$data){
                 $method = 'std'.$type;
                 $this->{$method}($data);
             });
 
-            $this->cleanUpProc($process, $process->getPid());
+            $this->stdout('Done, cleaning:'  . $pid . PHP_EOL);
+
+            $this->cleanUpProc($process, $pid);
         }
     }
 

--- a/tests/ProcessRunnerTest.php
+++ b/tests/ProcessRunnerTest.php
@@ -5,12 +5,13 @@ use Symfony\Component\Process\Process;
 
 class ProcessRunnerTest extends TestCase
 {
+    const CMD = 'ls > /dev/null';
     public function testRunnerRunSingle()
     {
         $runner = $this->getRunner();
         $this->assertEquals($runner->getIterator()->count(),0);
 
-        $runner->runProcess('ls -l');
+        $runner->runProcess(self::CMD);
 
         $this->assertEquals($runner->getIterator()->count(),1);
 
@@ -23,43 +24,26 @@ class ProcessRunnerTest extends TestCase
         $runner = $this->getRunner(2);
 
         $this->assertEquals($runner->getIterator()->count(),0);
-        $runner->runProcess('ls -l');
-        $runner->runProcess('ls -l');
+
+        $runner->runProcess(self::CMD);
+        $runner->runProcess(self::CMD);
+
         $this->assertEquals($runner->getIterator()->count(),2);
 
         $runner->cleanUpAll();
         $this->assertEquals($runner->getIterator()->count(),0);
-
     }
     public function testRunnerCleanUpProcess()
     {
-        $pid = 123;
         $runner = $this->getRunner();
 
-        $process = $this->createMock(Process::class);
-        $process->method('getPid')
-             ->willReturn($pid);
-
-        $process->method('checkTimeout')
-             ->willReturn(null);
-
-        $process->method('isRunning')
-             ->willReturn(false);
-
-        $process->method('getOutput')
-             ->willReturn('');
-
-        $process->method('getErrorOutput')
-             ->willReturn('');
-
-        $process->method('isSuccessful')
-             ->willReturn(true);
+        $process = new Process(self::CMD);
+        $process->run();
 
         $runner->addProcess($process);
-
         $this->assertEquals($runner->getIterator()->count(),1);
 
-        $runner->cleanUpProc($process, $pid);
+        $runner->cleanUpProc($process, $process->getPid());
 
         $this->assertEquals($runner->getIterator()->count(),0);
     }
@@ -68,9 +52,9 @@ class ProcessRunnerTest extends TestCase
         $runner = $this->getRunner(2);
         $start = time();
 
-        $runner->runProcess('setsid php -r "sleep(10);"');
+        $runner->runProcess('setsid php -r "sleep(10);" > /dev/null');
         $this->assertEquals($runner->getIterator()->count(),1);
-        $runner->runProcess('setsid php -r "sleep(10);"');
+        $runner->runProcess('setsid php -r "sleep(10);" > /dev/null');
         $this->assertEquals($runner->getIterator()->count(),2);
 
         $runner->cleanUpAll(SIGKILL, true);

--- a/tests/ProcessRunnerTest.php
+++ b/tests/ProcessRunnerTest.php
@@ -51,7 +51,7 @@ class ProcessRunnerTest extends TestCase
     {
         $runner = $this->getRunner(2);
         $start = time();
-
+	
         $runner->runProcess('setsid php -r "sleep(10);" > /dev/null');
         $this->assertEquals($runner->getIterator()->count(),1);
         $runner->runProcess('setsid php -r "sleep(10);" > /dev/null');

--- a/tests/ProcessRunnerTest.php
+++ b/tests/ProcessRunnerTest.php
@@ -1,0 +1,92 @@
+<?php
+
+use UrbanIndo\Yii2\Queue\ProcessRunner;
+use Symfony\Component\Process\Process;
+
+class ProcessRunnerTest extends TestCase
+{
+    public function testRunnerRunSingle()
+    {
+        $runner = $this->getRunner();
+        $this->assertEquals($runner->getIterator()->count(),0);
+
+        $runner->runProcess('ls -l');
+
+        $this->assertEquals($runner->getIterator()->count(),1);
+
+        $runner->cleanUpAll();
+
+        $this->assertEquals($runner->getIterator()->count(),0);
+    }
+    public function testRunnerRunMultiple()
+    {
+        $runner = $this->getRunner(2);
+
+        $this->assertEquals($runner->getIterator()->count(),0);
+        $runner->runProcess('ls -l');
+        $runner->runProcess('ls -l');
+        $this->assertEquals($runner->getIterator()->count(),2);
+
+        $runner->cleanUpAll();
+        $this->assertEquals($runner->getIterator()->count(),0);
+
+    }
+    public function testRunnerCleanUpProcess()
+    {
+        $pid = 123;
+        $runner = $this->getRunner();
+
+        $process = $this->createMock(Process::class);
+        $process->method('getPid')
+             ->willReturn($pid);
+
+        $process->method('checkTimeout')
+             ->willReturn(null);
+
+        $process->method('isRunning')
+             ->willReturn(false);
+
+        $process->method('getOutput')
+             ->willReturn('');
+
+        $process->method('getErrorOutput')
+             ->willReturn('');
+
+        $process->method('isSuccessful')
+             ->willReturn(true);
+
+        $runner->addProcess($process);
+
+        $this->assertEquals($runner->getIterator()->count(),1);
+
+        $runner->cleanUpProc($process, $pid);
+
+        $this->assertEquals($runner->getIterator()->count(),0);
+    }
+    public function testRunnerPropagateSignals()
+    {
+        $runner = $this->getRunner(2);
+        $start = time();
+
+        $runner->runProcess('setsid php -r "sleep(10);"');
+        $this->assertEquals($runner->getIterator()->count(),1);
+        $runner->runProcess('setsid php -r "sleep(10);"');
+        $this->assertEquals($runner->getIterator()->count(),2);
+
+        $runner->cleanUpAll(SIGKILL, true);
+        $duration = time() - $start;
+        $this->assertEquals($runner->getIterator()->count(),0);
+        $this->assertLessThan(10, $duration);
+    }
+    protected function getRunner($proc = 1)
+    {
+        $queue = Yii::createObject([
+            'class' => '\UrbanIndo\Yii2\Queue\Queues\MemoryQueue',
+            'maxProcesses' => $proc,
+        ]);
+        $runner = new ProcessRunner();
+        $runner->setQueue($queue);
+
+        return $runner;
+    }
+}

--- a/tests/ProcessRunnerTest.php
+++ b/tests/ProcessRunnerTest.php
@@ -13,7 +13,7 @@ class ProcessRunnerTest extends TestCase
 
         $runner->runProcess(self::CMD);
 
-        $this->assertEquals($runner->getIterator()->count(),1);
+        $this->assertEquals($runner->getIterator()->count(),0);
 
         $runner->cleanUpAll();
 

--- a/tests/Queues/MultipleQueueTest.php
+++ b/tests/Queues/MultipleQueueTest.php
@@ -1,7 +1,7 @@
 <?php
 
 class MultipleQueueTest extends PHPUnit_Framework_TestCase {
-    
+
     public function test() {
         $queue = Yii::createObject([
             'class' => '\UrbanIndo\Yii2\Queue\Queues\MultipleQueue',
@@ -23,7 +23,7 @@ class MultipleQueueTest extends PHPUnit_Framework_TestCase {
                 'class' => 'UrbanIndo\Yii2\Queue\Strategies\RandomStrategy',
             ]
         ]);
-        
+
         $this->assertTrue($queue instanceof UrbanIndo\Yii2\Queue\Queues\MultipleQueue);
         /* @var $queue UrbanIndo\Yii2\Queue\MultipleQueue */
         $this->assertCount(4, $queue->queues);
@@ -32,12 +32,12 @@ class MultipleQueueTest extends PHPUnit_Framework_TestCase {
         }
         $this->assertTrue($queue->strategy instanceof \UrbanIndo\Yii2\Queue\Strategies\Strategy);
         $this->assertTrue($queue->strategy instanceof \UrbanIndo\Yii2\Queue\Strategies\RandomStrategy);
-        
+
         $queue0 = $queue->getQueue(0);
         $this->assertTrue($queue0 instanceof \UrbanIndo\Yii2\Queue\Queues\MemoryQueue);
         $queue4 = $queue->getQueue(4);
         $this->assertNull($queue4);
-        
+
         $njob = $queue->strategy->fetch();
         $this->assertFalse($njob);
         $i = 0;
@@ -56,13 +56,14 @@ class MultipleQueueTest extends PHPUnit_Framework_TestCase {
         $this->assertContains($index, range(0, 3));
         $fjob1->runCallable();
         $this->assertEquals(1, $i);
-        
-        $queue->postToQueue(new \UrbanIndo\Yii2\Queue\Job([
+
+        $job = new \UrbanIndo\Yii2\Queue\Job([
             'route' => function() use (&$i) {
                 $i += 1;
             }
-        ]), 3);
-        
+        ]);
+        $queue->postToQueue($job, 3);
+
         do {
             //this some times will exist
             $fjob2 = $queue->fetch();


### PR DESCRIPTION
hey mate, 

this is the pr for #70 

have a look, there was a bunch of code in the controller which shouldnt be there, forked it out, along with a bunch of methods to control the processes so that no zombies should stay defunct, am running it in production for a week already, no issues so far

the functionality should pretty much stay as it is, added a few more options to the queue component

when multi threading is disabled, the runner waits for process to finish, when not its runs it in background and then collects the zombie when convenient

the only thing, am not sure about the compatibility with older symfony process, i was running 3.3

if you accept and release, strongly recommend to bump up the version to 2.0

i was running testing with php 5.6 and 7.1 and only the DbQueue
