### PR TITLE
DEV: add php-pcntl as dependency to composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.5.0",
+        "ext-pcntl": "*",
         "yiisoft/yii2": "*",
         "aws/aws-sdk-php": ">=2.4",
         "symfony/process": ">=2.4",


### PR DESCRIPTION
got an exeption in one system from here 
https://github.com/urbanindo/yii2-queue/blob/9007970019dbcc652dd34991ca833a8c8c4c15cb/src/ProcessRunner.php#L341-L342