### PR TITLE
php 7.2 compatible

### DIFF
--- a/src/Job.php
+++ b/src/Job.php
@@ -14,7 +14,7 @@ namespace UrbanIndo\Yii2\Queue;
  * @author Petra Barus <petra.barus@gmail.com>
  * @since 2015.02.24
  */
-class Job extends \yii\base\Object
+class Job extends \yii\base\BaseObject
 {
 
     /**

--- a/src/Strategies/Strategy.php
+++ b/src/Strategies/Strategy.php
@@ -17,7 +17,7 @@ use UrbanIndo\Yii2\Queue\Job;
  * @author Petra Barus <petra.barus@gmail.com>
  * @since 2015.02.25
  */
-abstract class Strategy extends \yii\base\Object
+abstract class Strategy extends \yii\base\BaseObject
 {
 
     /**


### PR DESCRIPTION
Fixed 
PHP Compile Error 'yii\base\ErrorException' with message 'Cannot use 'Object' as class name as it is reserved'